### PR TITLE
Worker resilience, smarter load balancing, and connection stability

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,8 +42,8 @@ const config = {
     workerSettings: {
       dtlsCertificateFile: certFile,
       dtlsPrivateKeyFile: keyFile,
-      rtcMinPort: parseInt(process.env.RTC_MIN_PORT || '2000'),
-      rtcMaxPort: parseInt(process.env.RTC_MAX_PORT || '2300'),
+      rtcMinPort: parseInt(process.env.RTC_MIN_PORT || '10000'),
+      rtcMaxPort: parseInt(process.env.RTC_MAX_PORT || '60000'),
       logLevel: 'warn' as mediasoupTypes.WorkerLogLevel,
       logTags: [
         'info',

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -41,4 +41,12 @@ export const ValidationSchema = {
   restartIce: roomIdPeerIdSchema.extend({
     transportId: z.string(),
   }),
+
+  setConsumerPreferredLayers: roomIdPeerIdSchema.extend({
+    consumerId: z.string(),
+    producerPeerId: z.string(),
+    producerSource: producerSource,
+    spatialLayer: z.number(),
+    temporalLayer: z.number().optional(),
+  }),
 };

--- a/src/servers/mediasoup-server.ts
+++ b/src/servers/mediasoup-server.ts
@@ -8,9 +8,11 @@ import config from '../config';
 interface WorkerInfo {
   pid: number;
   worker: mediasoupTypes.Worker;
-  load: number;
+  load: number; // Keep for backward compatibility, but use score instead
   isHealthy: boolean;
   usage?: mediasoupTypes.WorkerResourceUsage;
+  score?: number; // Weighted load score based on CPU, memory, and peer count
+  lastUsageUpdate?: number; // Timestamp of last usage check
 }
 
 interface ServerMetrics {
@@ -100,7 +102,7 @@ export class MediasoupServer {
   private setupWorkerEventHandlers(worker: mediasoupTypes.Worker): void {
     worker.once('died', () => {
       console.error(`Worker ${worker.pid} died unexpectedly`);
-      // this.handleWorkerDeath(worker.pid);
+      this.handleWorkerDeath(worker.pid);
     });
 
     worker.on('subprocessclose', () => {
@@ -112,6 +114,40 @@ export class MediasoupServer {
       console.info(`Worker ${worker.pid} closed`);
       this.workers.delete(worker.pid);
     });
+  }
+
+  private async handleWorkerDeath(workerPid: number): Promise<void> {
+    try {
+      console.error(`Handling death of worker ${workerPid}`);
+
+      // Get worker info before removal
+      const deadWorkerInfo = this.workers.get(workerPid);
+      if (!deadWorkerInfo) {
+        console.warn(`Worker ${workerPid} not found in workers map`);
+        return;
+      }
+
+      // Mark worker as unhealthy immediately
+      deadWorkerInfo.isHealthy = false;
+
+      // Remove dead worker from map
+      this.workers.delete(workerPid);
+      console.info(`Removed dead worker ${workerPid} from workers map`);
+
+      // Spawn replacement worker
+      const currentWorkerCount = this.workers.size;
+      console.info(
+        `Spawning replacement worker (current count: ${currentWorkerCount})`
+      );
+
+      await this.createSingleWorker(currentWorkerCount);
+      console.info(
+        `Successfully spawned replacement worker (new count: ${this.workers.size})`
+      );
+    } catch (error) {
+      console.error(`Failed to handle worker death for ${workerPid}:`, error);
+      // Continue execution - don't throw, as this is an error handler
+    }
   }
 
   increaseWorkerLoad(workerPid: number): boolean {
@@ -149,7 +185,54 @@ export class MediasoupServer {
     return Array.from(this.workers.values()).filter(info => info.isHealthy);
   }
 
-  getLeastLoadedWorker(): mediasoupTypes.Worker | null {
+  private async calculateWorkerScore(
+    workerInfo: WorkerInfo
+  ): Promise<number> {
+    try {
+      // Refresh usage if stale (older than 2 seconds)
+      const now = Date.now();
+      if (
+        !workerInfo.lastUsageUpdate ||
+        now - workerInfo.lastUsageUpdate > 2000
+      ) {
+        workerInfo.usage = await workerInfo.worker.getResourceUsage();
+        workerInfo.lastUsageUpdate = now;
+      }
+
+      const usage = workerInfo.usage;
+      if (!usage) {
+        // Fallback to naive load if no usage data
+        return workerInfo.load * 100;
+      }
+
+      // Calculate normalized metrics (0-100 scale)
+      // CPU usage is already a percentage (0-100)
+      const cpuScore = usage.ru_utime + usage.ru_stime; // User + system CPU time
+
+      // Memory usage (convert to percentage, assume 4GB max per worker)
+      const maxMemoryMB = 4096;
+      const memoryMB = usage.ru_maxrss / 1024; // Convert KB to MB
+      const memoryScore = (memoryMB / maxMemoryMB) * 100;
+
+      // Peer count score (normalize by maxWorkerLoad)
+      const peerScore = (workerInfo.load / this.maxWorkerLoad) * 100;
+
+      // Weighted score: 40% CPU, 30% memory, 30% peer count
+      const weightedScore =
+        cpuScore * 0.4 + memoryScore * 0.3 + peerScore * 0.3;
+
+      return weightedScore;
+    } catch (error) {
+      console.error(
+        `Failed to calculate score for worker ${workerInfo.pid}:`,
+        error
+      );
+      // Fallback to naive load
+      return workerInfo.load * 100;
+    }
+  }
+
+  async getLeastLoadedWorker(): Promise<mediasoupTypes.Worker | null> {
     const healthyWorkers = this.getHealthyWorkers();
 
     if (healthyWorkers.length === 0) {
@@ -157,15 +240,27 @@ export class MediasoupServer {
       return null;
     }
 
-    const leastLoaded = healthyWorkers.reduce((min, current) =>
-      current.load < min.load ? current : min
+    // Calculate scores for all healthy workers
+    const workersWithScores = await Promise.all(
+      healthyWorkers.map(async workerInfo => ({
+        workerInfo,
+        score: await this.calculateWorkerScore(workerInfo),
+      }))
     );
 
-    return leastLoaded.worker;
+    // Find worker with lowest score
+    const leastLoaded = workersWithScores.reduce((min, current) =>
+      current.score < min.score ? current : min
+    );
+
+    // Update the score in workerInfo for monitoring
+    leastLoaded.workerInfo.score = leastLoaded.score;
+
+    return leastLoaded.workerInfo.worker;
   }
 
   async getWorkerWithCapacity(): Promise<mediasoupTypes.Worker | null> {
-    const worker = this.getLeastLoadedWorker();
+    const worker = await this.getLeastLoadedWorker();
     if (!worker) return null;
 
     const workerInfo = this.workers.get(worker.pid);
@@ -185,7 +280,7 @@ export class MediasoupServer {
     }
 
     try {
-      const worker = this.getLeastLoadedWorker();
+      const worker = await this.getLeastLoadedWorker();
       if (!worker) {
         throw new Error('No healthy workers available for router creation');
       }

--- a/src/services/medianode.ts
+++ b/src/services/medianode.ts
@@ -83,7 +83,7 @@ class MediaNode extends EventEmitter {
         sendPipeTansportsMap.set(routerId, transport);
       }
 
-      const recvRouter = room.getLeastLoadedRouter();
+      const recvRouter = await room.getLeastLoadedRouter();
       if (!recvRouter) throw 'No router found';
       // const recvPipeTransport = await meeting.createPipeTransport({ router: recvRouter });
 

--- a/src/services/room.ts
+++ b/src/services/room.ts
@@ -168,7 +168,7 @@ class Room extends EventEmitter {
   }
 
   async assignRouterToPeer(): Promise<mediasoupTypes.Router | null> {
-    const router = this.getLeastLoadedRouter();
+    const router = await this.getLeastLoadedRouter();
     if (router) {
       await this.pipeProducersToRouter(router);
       return router;
@@ -184,11 +184,11 @@ class Room extends EventEmitter {
     );
   }
 
-  getLeastLoadedRouter(): mediasoupTypes.Router | null {
+  async getLeastLoadedRouter(): Promise<mediasoupTypes.Router | null> {
     // the least loaded router,
     // is the room router of the least loaded worker
 
-    const leastLoadedWorker = mediaSoupServer.getLeastLoadedWorker();
+    const leastLoadedWorker = await mediaSoupServer.getLeastLoadedWorker();
 
     if (!leastLoadedWorker) throw 'Least Loaded Worker not found';
 

--- a/src/services/signalnode.ts
+++ b/src/services/signalnode.ts
@@ -788,15 +788,18 @@ class SignalNode extends EventEmitter {
         });
 
         // Pipe Producer From This Router to other routers
+        // Must await before creating consumers so cross-router canConsume() works
         const routersToPipeTo = room.getRoutersToPipeTo(peer.getRouter());
-        routersToPipeTo.forEach(router => {
-          peer
-            .pipeToRouter({
-              router,
-              producerId: producer.id,
-            })
-            .catch(error => console.log(error));
-        });
+        await Promise.all(
+          routersToPipeTo.map(router =>
+            peer
+              .pipeToRouter({
+                router,
+                producerId: producer.id,
+              })
+              .catch(error => console.log(error))
+          )
+        );
 
         // Create server-side consumer for each existing peers
         const existingPeers = room.getPeers();

--- a/src/services/signalnode.ts
+++ b/src/services/signalnode.ts
@@ -886,6 +886,38 @@ class SignalNode extends EventEmitter {
       console.log('ResumeConsumer', args);
     },
 
+    [Actions.SetConsumerPreferredLayers]: async args => {
+      try {
+        const data = ValidationSchema.setConsumerPreferredLayers.parse(args);
+        const { roomId, peerId, consumerId, spatialLayer, temporalLayer } =
+          data;
+
+        const room = Room.getRoom(roomId);
+        const peer = room?.getPeer(peerId);
+
+        if (!room || !peer) {
+          throw 'Failed to set consumer preferred layers: Peer/room not found';
+        }
+
+        const consumer = peer.getConsumer(consumerId);
+        if (!consumer) {
+          throw 'Consumer not found';
+        }
+
+        // Set preferred layers on the consumer
+        await consumer.setPreferredLayers({
+          spatialLayer,
+          temporalLayer: temporalLayer ?? spatialLayer,
+        });
+
+        console.log(
+          `Set consumer preferred layers: ${consumerId}, spatial: ${spatialLayer}, temporal: ${temporalLayer ?? spatialLayer}`
+        );
+      } catch (error) {
+        console.error('SetConsumerPreferredLayers error:', error);
+      }
+    },
+
     [Actions.RestartIce]: async (args, requestId) => {
       try {
         if (!requestId) throw 'Require request id';

--- a/src/services/signalnode.ts
+++ b/src/services/signalnode.ts
@@ -92,7 +92,28 @@ class SignalNode extends EventEmitter {
     }
   }
 
-  private setupHeartbeat(): void {}
+  private setupHeartbeat(): void {
+    this.lastHeartbeat = Date.now();
+    this.heartbeatInterval = setInterval(() => {
+      const staleness = Date.now() - this.lastHeartbeat;
+      if (staleness > this.heartbeatTimeout) {
+        console.warn(
+          `SignalNode ${this.id} heartbeat timeout (${staleness}ms) — disconnecting`
+        );
+        this.handleClientDisconnection('heartbeat_timeout');
+        return;
+      }
+      try {
+        this.sendMessage(Actions.Heartbeat, {
+          timestamp: Date.now(),
+          nodeId: this.id,
+          connectionId: this.connectionId,
+        });
+      } catch (error) {
+        console.warn(`Failed to send heartbeat for ${this.id}:`, error);
+      }
+    }, 30000);
+  }
 
   private clearHeartbeat(): void {
     if (this.heartbeatInterval) {
@@ -169,18 +190,23 @@ class SignalNode extends EventEmitter {
         return;
       }
 
+      if (action === Actions.HeartbeatAck) {
+        this.lastHeartbeat = Date.now();
+        return;
+      }
+
       // Find and execute handler
       const handler = this.actionHandlers[action as Actions];
       if (handler) {
-        try {
-          handler(parsedArgs, requestId);
-        } catch (handlerError) {
-          console.error(
-            ` Error in handler for action ${action} from ${this.id}:`,
-            handlerError
-          );
-          this.handleError(handlerError as Error, 'handler_error');
-        }
+        Promise.resolve()
+          .then(() => handler(parsedArgs, requestId))
+          .catch((handlerError: Error) => {
+            console.error(
+              `Error in handler for action ${action} from ${this.id}:`,
+              handlerError
+            );
+            this.handleError(handlerError, 'handler_error');
+          });
       } else {
         console.warn(`⚠️  No handler for action ${action} from ${this.id}`);
         this.emit('unhandledMessage', {
@@ -290,6 +316,7 @@ class SignalNode extends EventEmitter {
     if (!this.call) {
       throw `Cannot send message to MediaNode ${this.id}: not connected`;
     }
+    const REQUEST_TIMEOUT_MS = 30000;
     const requestId = crypto.randomUUID();
     const message: MessageRequest = {
       action,
@@ -299,9 +326,26 @@ class SignalNode extends EventEmitter {
 
     return new Promise<ResponseData>((resolve, reject) => {
       if (this.call) {
+        const timeout = setTimeout(() => {
+          if (this.pendingRequests.has(requestId)) {
+            this.pendingRequests.delete(requestId);
+            reject(
+              new Error(
+                `Request timeout after ${REQUEST_TIMEOUT_MS}ms for action ${action}`
+              )
+            );
+          }
+        }, REQUEST_TIMEOUT_MS);
+
         this.pendingRequests.set(requestId, {
-          resolve,
-          reject,
+          resolve: data => {
+            clearTimeout(timeout);
+            resolve(data);
+          },
+          reject: err => {
+            clearTimeout(timeout);
+            reject(err);
+          },
         });
         this.call.write(message);
       }
@@ -566,7 +610,7 @@ class SignalNode extends EventEmitter {
     [key in Actions]?: (
       args: { [key: string]: unknown },
       requestId?: string
-    ) => void;
+    ) => void | Promise<void>;
   } = {
     [Actions.Connected]: args => {
       console.log(`Connection confirmed from ${this.id}:`, args);

--- a/src/services/signalnode.ts
+++ b/src/services/signalnode.ts
@@ -703,10 +703,27 @@ class SignalNode extends EventEmitter {
           throw 'Failed to create webrtc transport: Peer/room not found';
         const existingPeers = room.getPeers();
 
-        // create consumer from producers of existing peers
-        existingPeers.forEach(existingPeer => {
-          // ingore the peer that requested this
-          if (existingPeer.id === peerId) return;
+        // Selective consumer creation to avoid O(n²) explosion
+        // Only create consumers for:
+        // 1. First N peers (viewport/pagination limit)
+        // 2. Active speakers (TODO: implement active speaker detection)
+        // 3. Pinned/featured peers (TODO: implement when UI supports it)
+
+        const maxInitialConsumers = parseInt(
+          process.env.MAX_INITIAL_CONSUMERS || '25'
+        );
+
+        // Filter out the requesting peer and limit to maxInitialConsumers
+        const peersToConsume = existingPeers
+          .filter(existingPeer => existingPeer.id !== peerId)
+          .slice(0, maxInitialConsumers);
+
+        console.info(
+          `Creating consumers for ${peersToConsume.length}/${existingPeers.length - 1} peers (selective subscription)`
+        );
+
+        // create consumer from producers of selected peers
+        peersToConsume.forEach(existingPeer => {
           const peerProducers = existingPeer.getProducers();
           peerProducers.forEach(producer => {
             this.createConsumer({

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -18,6 +18,7 @@ export enum Actions {
   CloseConsumer = 'close_consumer',
   ResumeConsumer = 'resume_consumer',
   PauseConsumer = 'pause_consumer',
+  SetConsumerPreferredLayers = 'set_consumer_preferred_layers',
 
   // consumed by client
   ConsumerCreated = 'consumer_created',


### PR DESCRIPTION
# Worker resilience, smarter load balancing, and connection stability

## Summary

- **Worker auto-recovery**: Implement `handleWorkerDeath` to automatically replace dead mediasoup workers instead of silently losing them. Dead workers are removed from the pool and a replacement is spawned immediately.
- **Weighted load scoring**: Replace naive peer-count load balancing with a weighted score (40% CPU, 30% memory, 30% peer count) using real resource usage data. `getLeastLoadedWorker` is now async to support live usage polling.
- **Heartbeat mechanism**: Implement `setupHeartbeat` in `SignalNode` — sends a ping every 30s and disconnects the client on timeout, preventing zombie connections from silently accumulating.
- **Request timeouts**: Add a 30s timeout to all pending `sendRequest` calls so hung requests fail fast instead of leaking memory indefinitely.
- **Selective consumer creation**: Cap initial consumer creation at `MAX_INITIAL_CONSUMERS` (default 25) when a peer joins, preventing O(n²) transport explosion in large rooms.
- **Concurrent router piping**: Switch producer-to-router piping from sequential `forEach` to `Promise.all`, ensuring cross-router `canConsume()` checks work correctly before consumers are created.
- **Expanded RTC port range**: Widen default range from `2000–2300` to `10000–60000` to support higher peer counts.

## Test plan

- [ ] Join a room with an existing peer — verify consumers are created up to the `MAX_INITIAL_CONSUMERS` limit
- [ ] Kill a mediasoup worker process mid-call — verify a replacement worker is spawned and the server remains healthy
- [ ] Let a client go silent (no heartbeat ack) for >30s — verify it is disconnected with `heartbeat_timeout`
- [ ] Trigger a slow/stuck action handler — verify the pending request rejects after 30s with a timeout error
- [ ] Confirm existing multi-router piping still works (producers visible across routers)
